### PR TITLE
Temporary fix of flaky test in CircleCI

### DIFF
--- a/cypress/integration/lab.test.js
+++ b/cypress/integration/lab.test.js
@@ -24,6 +24,8 @@ describe("Index", () => {
   it("shows five cards from the retrieved deck ID when the button is clicked", () => {
     visitWithFirstDeck();
 
+    clickForDeck("cards1.json");
+
     cy.fixture("cards1.json").then((cardsFixture1) => {
       cy.get(".card")
         .should("have.length", 5)


### PR DESCRIPTION
Cypress is behaving differently on CircleCI than on people's local machines.
This causes a problem where the tests pass locally, but fail in the cloud.
Here is what I observed happening in Circle:
1. Cypress visits the page
1. An API call is made to get the new deck of cards.
1. Cypress clicks on the `Get Cards` button.
1. The cards never appear on the page and are never found.

There is some mysterious behavior here: for example if there is a `<form />` element on the page, Cypress on Circle will reload the page, **even if `event.preventDefault()` is called**. This messes up the order of the API calls.

Even when form elements are removed and the page no longer loads, this still does not work on Cypress in CircleCI.

Another interesting observation is that the final test DOES pass:
1. Do the above and draw 5 cards.
1. Draw 3 more cards.
1. 3 cards appear as expected.

Based on this, I kind of arbitrarily added a second call to draw the cards. This makes the test pass!

There is still a mystery here and probably a bug in someone's code. In the meantime, this change will allow the tests to pass.

I tested this change with the 3 PRs we have so far from fellows that passed locally but failed on GitHub. Success in all cases. Proof: https://github.com/joinpursuit/fix-async-await-lab/compare/mb-fix-flaky-test?expand=1